### PR TITLE
Revelation tag - display bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -128,7 +128,8 @@ function expose(rule, s)
     match_clients(rule, capi.client.get(scr), t)
     local function restore()
         awful.tag.history.restore()
-        t.screen = nil
+	awful.tag.setscreen(t, nil)
+        t.selected = false
         capi.keygrabber.stop()
         capi.mousegrabber.stop()
 


### PR DESCRIPTION
Used standard awful API to set the screen for the revelation tag to nil.
Also added a line that sets the selection of the tag to false, otherwise in many cases
the tag was displayed after the expose menu was closed.
